### PR TITLE
update available regions

### DIFF
--- a/modules/reference/pages/aws.adoc
+++ b/modules/reference/pages/aws.adoc
@@ -2,12 +2,15 @@
 
 == Regions
 
-* US-West-1 (N.Cal)
-* US-East-1 (N. Virginia)
-* EU-West-1 (Ireland)
-* EU-West-2 (UK)
-* EU-Central-1 (Germany)
-* AP-Northeast-1 (Japan)
+* US-West-1 (Northern California, USA)
+* US-East-1 (Northern Virginia, USA)
+* EU-West-1 (Dublin, Ireland)
+* EU-West-2 (London, UK)
+* EU-Central-1 (Frankfurt, Germany)
+* AP-Northeast-1 (Tokyo, Japan)
+* AP-Southeast-1 (Singapore)
+* AP-Southeast-2 (Sydney, Australia)
+* SA-East-1 (São Paulo, Brazil)
 
 == Instance types
 
@@ -19,7 +22,7 @@ The table below shows the instance types available on AWS.
 | TG.Free
 | 4
 | 7.5
-| 0
+| $0.00
 
 | TG.C4.M16
 | 4

--- a/modules/reference/pages/azure.adoc
+++ b/modules/reference/pages/azure.adoc
@@ -2,15 +2,23 @@
 
 == Regions
 
-* West US
-* West Europe
-* Central India
-* South India
+* East US (Virginia)
+* East US (Virginia 2)
+* West US (California)
+* West Europe (Amsterdam)
+* Central India (Pune)
+* South India (Chennai)
+* Australia East (New South Wales)
 
 == Instance types
 
 |===
 | Instance name | vCPU | RAM (GiB) | Price per hour
+
+|TG.C4.M16
+|4
+|16
+|$1.20
 
 | TG.C8.M16
 | 8

--- a/modules/reference/pages/gcp.adoc
+++ b/modules/reference/pages/gcp.adoc
@@ -2,8 +2,10 @@
 
 == Regions
 
-* Oregon
-* London
+* US-West1 (Oregon)
+* Europe-West2 (London)
+* Asia-Southeast1 (Singapore)
+* Australia-Southeast1 (Australia)
 
 == Instance types
 


### PR DESCRIPTION
I unified the style of the regions because the TGCloud interface has different wording than the official vendor wording. The style is:

* <vendor's name for region> (\<TG name for region>)