### PR TITLE
Expand .gitignore for Antora and local tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,26 @@
-.idea/
+# Dependencies
+node_modules/
+
+# Antora build output and cache
+build/
+.cache/
+antora.log
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Lockfile — yarn.lock is the committed source of truth
+package-lock.json
+
+# OS
 .DS_Store
-node_modules
-build
+Thumbs.db
+
+# Editors / IDEs
+.idea/
+.vscode/
+*.swp
+*~


### PR DESCRIPTION
## Summary
- Expand `.gitignore` to cover Antora cache/output, logs, OS/editor files, and `package-lock.json`
- Keep `yarn.lock` as the committed lockfile source of truth and stop local build artifacts from showing up as untracked files

## Test plan
- [ ] Confirm `git status` is clean after a local `npm`/`yarn` install and `npm run build`
- [ ] Confirm `.cache/`, `build/`, `antora.log`, and `package-lock.json` are ignored
- [ ] Confirm `yarn.lock` is still tracked